### PR TITLE
Add Reclaim SDK logging configuration

### DIFF
--- a/components/ReclaimComponent.tsx
+++ b/components/ReclaimComponent.tsx
@@ -8,6 +8,24 @@ import { Alert, StyleSheet, Text, TouchableOpacity, View } from "react-native";
 
 const reclaimVerification = new ReclaimVerification();
 
+// Configure logging to listen to all SDK logs
+reclaimVerification.setOverrides({
+  logConsumer: {
+    // Listen to all SDK logs
+    onLogs: (logJsonString, cancel) => {
+      console.log('[Reclaim SDK]:', logJsonString);
+      // You can process logs here or send them to your logging service
+      // Call cancel() to stop receiving logs
+    },
+    
+    // Control telemetry (default: true)
+    canSdkCollectTelemetry: true,
+    
+    // Control console logging (default: enabled in dev mode)
+    canSdkPrintLogs: true
+  }
+});
+
 const RUM_CONTRACT_ADDRESS = process.env.EXPO_PUBLIC_RUM_CONTRACT_ADDRESS ?? "";
 
 const reclaimConfig = {


### PR DESCRIPTION
## Summary
- Configure Reclaim SDK to log all events for improved debugging capabilities

## Changes Made
1. **Added logging configuration to ReclaimComponent**
   - Uses `setOverrides` with `logConsumer` configuration
   - All SDK logs are prefixed with `[Reclaim SDK]:` for easy filtering
   - Maintains default telemetry (`canSdkCollectTelemetry: true`)
   - Maintains default console logging (`canSdkPrintLogs: true`)

## Benefits
- Better visibility into SDK operations during development
- Easier debugging of verification flow issues
- Can intercept logs for custom logging services if needed
- Ability to disable logging by calling `cancel()` function

## Test Plan
- [ ] Run the app and trigger the Reclaim verification flow
- [ ] Check console for `[Reclaim SDK]:` prefixed logs
- [ ] Verify all SDK events are being logged
- [ ] Ensure no performance impact from logging