### PR TITLE
docs: fix typo in README - Abstaxion to Abstraxion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Welcome to your Abstaxion x Reclaim Expo App
+# Welcome to your Abstraxion x Reclaim Expo App
 
 For more elaborate docs, please visit: https://docs.burnt.com/xion/developers/mobile-app-development/zktls-integration-using-reclaim-in-a-xion-mobile-app
 


### PR DESCRIPTION
## Summary

Fixed a typo in the README.md title where "Abstaxion" was misspelled - it should be "Abstraxion" (missing 'r').

## Changes

- Changed "Abstaxion x Reclaim Expo App" to "Abstraxion x Reclaim Expo App"

This aligns with the correct project name and the package import `@burnt-labs/abstraxion-react-